### PR TITLE
URL Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 This repository contains example of how to use embedded tc Server with Spring Boot via tcserver-spring-boot. 
 
-These samples assume you have some familiarity with Spring Boot and tc Server. More information about Spring Boot may be found at [http://projects.spring.io/spring-boot/]().
+These samples assume you have some familiarity with Spring Boot and tc Server. More information about Spring Boot may be found at [https://projects.spring.io/spring-boot/]().
 
 Prerequisites
 =============
 To use these samples you will need
 
-* Register for free access to Pivotal Commercial Maven Repository - [http://commercial-repo.pivotal.io/](http://commercial-repo.pivotal.io/)
+* Register for free access to Pivotal Commercial Maven Repository - [https://commercial-repo.pivotal.io/](https://commercial-repo.pivotal.io/)
 * JRE/JDK 8 or newer
 
 Samples
@@ -46,8 +46,8 @@ In the above example you will need to replace YOUR\_EMAIL\_ADDRESS and YOUR\_PAS
 Documentation References
 ==========
 
-* Spring Boot - [http://docs.spring.io/spring-boot/docs/1.2.2.RELEASE/reference/htmlsingle/](http://docs.spring.io/spring-boot/docs/1.2.2.RELEASE/reference/htmlsingle/)
-* tc Server -  [http://tcserver.docs.pivotal.io/index.html](http://tcserver.docs.pivotal.io/index.html)
+* Spring Boot - [https://docs.spring.io/spring-boot/docs/1.2.2.RELEASE/reference/htmlsingle/](https://docs.spring.io/spring-boot/docs/1.2.2.RELEASE/reference/htmlsingle/)
+* tc Server -  [https://tcserver.docs.pivotal.io/index.html](https://tcserver.docs.pivotal.io/index.html)
 
 License
 =======


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://docs.spring.io/spring-boot/docs/1.2.2.RELEASE/reference/htmlsingle/ with 2 occurrences migrated to:  
  https://docs.spring.io/spring-boot/docs/1.2.2.RELEASE/reference/htmlsingle/ ([https](https://docs.spring.io/spring-boot/docs/1.2.2.RELEASE/reference/htmlsingle/) result 200).
* http://projects.spring.io/spring-boot/ with 1 occurrences migrated to:  
  https://projects.spring.io/spring-boot/ ([https](https://projects.spring.io/spring-boot/) result 200).
* http://tcserver.docs.pivotal.io/index.html with 2 occurrences migrated to:  
  https://tcserver.docs.pivotal.io/index.html ([https](https://tcserver.docs.pivotal.io/index.html) result 301).
* http://commercial-repo.pivotal.io/ with 2 occurrences migrated to:  
  https://commercial-repo.pivotal.io/ ([https](https://commercial-repo.pivotal.io/) result 302).