### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,7 +1,7 @@
 
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -193,7 +193,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/tcserver-spring-boot-sample-actuator/src/main/java/sample/tcserver/actuator/SampleTcServerActuatorApplication.java
+++ b/tcserver-spring-boot-sample-actuator/src/main/java/sample/tcserver/actuator/SampleTcServerActuatorApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/tcserver-spring-boot-sample-actuator/src/main/java/sample/tcserver/actuator/web/SampleController.java
+++ b/tcserver-spring-boot-sample-actuator/src/main/java/sample/tcserver/actuator/web/SampleController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/tcserver-spring-boot-sample-actuator/src/test/java/sample/tomcat/SampleTomcatSslApplicationTests.java
+++ b/tcserver-spring-boot-sample-actuator/src/test/java/sample/tomcat/SampleTomcatSslApplicationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/tcserver-spring-boot-sample-jsp/src/main/java/sample/tomcat/jsp/MyException.java
+++ b/tcserver-spring-boot-sample-jsp/src/main/java/sample/tomcat/jsp/MyException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/tcserver-spring-boot-sample-jsp/src/main/java/sample/tomcat/jsp/MyRestResponse.java
+++ b/tcserver-spring-boot-sample-jsp/src/main/java/sample/tomcat/jsp/MyRestResponse.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/tcserver-spring-boot-sample-jsp/src/main/java/sample/tomcat/jsp/SampleTomcatJspApplication.java
+++ b/tcserver-spring-boot-sample-jsp/src/main/java/sample/tomcat/jsp/SampleTomcatJspApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/tcserver-spring-boot-sample-jsp/src/main/java/sample/tomcat/jsp/WelcomeController.java
+++ b/tcserver-spring-boot-sample-jsp/src/main/java/sample/tomcat/jsp/WelcomeController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/tcserver-spring-boot-sample-jsp/src/test/java/sample/tomcat/jsp/SampleWebJspApplicationTests.java
+++ b/tcserver-spring-boot-sample-jsp/src/test/java/sample/tomcat/jsp/SampleWebJspApplicationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/tcserver-spring-boot-sample-multi-connectors/src/main/java/sample/tomcat/multiconnector/SampleTomcatTwoConnectorsApplication.java
+++ b/tcserver-spring-boot-sample-multi-connectors/src/main/java/sample/tomcat/multiconnector/SampleTomcatTwoConnectorsApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/tcserver-spring-boot-sample-multi-connectors/src/main/java/sample/tomcat/multiconnector/web/SampleController.java
+++ b/tcserver-spring-boot-sample-multi-connectors/src/main/java/sample/tomcat/multiconnector/web/SampleController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/tcserver-spring-boot-sample-multi-connectors/src/test/java/sample/tomcat/multiconnector/SampleTomcatTwoConnectorsApplicationTests.java
+++ b/tcserver-spring-boot-sample-multi-connectors/src/test/java/sample/tomcat/multiconnector/SampleTomcatTwoConnectorsApplicationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/tcserver-spring-boot-sample-obfuscated-ssl-classpath/src/main/java/sample/tomcat/ssl/SampleTomcatSslApplication.java
+++ b/tcserver-spring-boot-sample-obfuscated-ssl-classpath/src/main/java/sample/tomcat/ssl/SampleTomcatSslApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/tcserver-spring-boot-sample-obfuscated-ssl-classpath/src/main/java/sample/tomcat/ssl/web/SampleController.java
+++ b/tcserver-spring-boot-sample-obfuscated-ssl-classpath/src/main/java/sample/tomcat/ssl/web/SampleController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/tcserver-spring-boot-sample-obfuscated-ssl-classpath/src/test/java/sample/tomcat/SampleTomcatSslApplicationTests.java
+++ b/tcserver-spring-boot-sample-obfuscated-ssl-classpath/src/test/java/sample/tomcat/SampleTomcatSslApplicationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/tcserver-spring-boot-sample-obfuscated-ssl/src/main/java/sample/tomcat/ssl/SampleTomcatSslApplication.java
+++ b/tcserver-spring-boot-sample-obfuscated-ssl/src/main/java/sample/tomcat/ssl/SampleTomcatSslApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/tcserver-spring-boot-sample-obfuscated-ssl/src/main/java/sample/tomcat/ssl/web/SampleController.java
+++ b/tcserver-spring-boot-sample-obfuscated-ssl/src/main/java/sample/tomcat/ssl/web/SampleController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/tcserver-spring-boot-sample-obfuscated-ssl/src/test/java/sample/tomcat/SampleTomcatSslApplicationTests.java
+++ b/tcserver-spring-boot-sample-obfuscated-ssl/src/test/java/sample/tomcat/SampleTomcatSslApplicationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/tcserver-spring-boot-sample-ssl/src/main/java/sample/tomcat/ssl/SampleTomcatSslApplication.java
+++ b/tcserver-spring-boot-sample-ssl/src/main/java/sample/tomcat/ssl/SampleTomcatSslApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/tcserver-spring-boot-sample-ssl/src/main/java/sample/tomcat/ssl/web/SampleController.java
+++ b/tcserver-spring-boot-sample-ssl/src/main/java/sample/tomcat/ssl/web/SampleController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/tcserver-spring-boot-sample-ssl/src/test/java/sample/tomcat/SampleTomcatSslApplicationTests.java
+++ b/tcserver-spring-boot-sample-ssl/src/test/java/sample/tomcat/SampleTomcatSslApplicationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/tcserver-spring-boot-sample/src/main/java/sample/tomcat/SampleTomcatApplication.java
+++ b/tcserver-spring-boot-sample/src/main/java/sample/tomcat/SampleTomcatApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/tcserver-spring-boot-sample/src/main/java/sample/tomcat/service/HelloWorldService.java
+++ b/tcserver-spring-boot-sample/src/main/java/sample/tomcat/service/HelloWorldService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/tcserver-spring-boot-sample/src/main/java/sample/tomcat/web/SampleController.java
+++ b/tcserver-spring-boot-sample/src/main/java/sample/tomcat/web/SampleController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/tcserver-spring-boot-sample/src/test/java/sample/tomcat/NonAutoConfigurationSampleTomcatApplicationTests.java
+++ b/tcserver-spring-boot-sample/src/test/java/sample/tomcat/NonAutoConfigurationSampleTomcatApplicationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/tcserver-spring-boot-sample/src/test/java/sample/tomcat/SampleTomcatApplicationTests.java
+++ b/tcserver-spring-boot-sample/src/test/java/sample/tomcat/SampleTomcatApplicationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/ with 1 occurrences migrated to:  
  https://www.apache.org/licenses/ ([https](https://www.apache.org/licenses/) result 200).
* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 26 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).