### PR TITLE
URL Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 This repository contains examples of how to use embedded tc Server with Spring Boot via tcserver-spring-boot.  Most of the samples are copies of existing spring-boot-samples-tomcat that have been modified to use embedded tc Server instead of tomcat.  Samples without a README.md just have their pom.xml files modified for tc Server Spring Boot Specifics.
 
-These samples assume you have some familiarity with Spring Boot and tc Server. More information about Spring Boot may be found at [http://projects.spring.io/spring-boot/]().
+These samples assume you have some familiarity with Spring Boot and tc Server. More information about Spring Boot may be found at [https://projects.spring.io/spring-boot/]().
 
 Prerequisites
 =============
 To use these samples you will need
 
-* Register for free access to Pivotal Commercial Maven Repository - [http://commercial-repo.pivotal.io/]()
+* Register for free access to Pivotal Commercial Maven Repository - [https://commercial-repo.pivotal.io/]()
 * JRE/JDK 7 or newer
 * Maven 3.2 or newer (Required by spring-boot-maven-plugin)
 
@@ -54,8 +54,8 @@ In the above example you will need to replace YOUR\_EMAIL\_ADDRESS and YOUR\_PAS
 Documentation References
 ==========
 
-* Spring Boot - [http://docs.spring.io/spring-boot/docs/1.2.2.RELEASE/reference/htmlsingle/](http://docs.spring.io/spring-boot/docs/1.2.2.RELEASE/reference/htmlsingle/)
-* tc Server -  [http://tcserver.docs.pivotal.io/index.html](http://tcserver.docs.pivotal.io/index.html)
+* Spring Boot - [https://docs.spring.io/spring-boot/docs/1.2.2.RELEASE/reference/htmlsingle/](https://docs.spring.io/spring-boot/docs/1.2.2.RELEASE/reference/htmlsingle/)
+* tc Server -  [https://tcserver.docs.pivotal.io/index.html](https://tcserver.docs.pivotal.io/index.html)
 
 License
 =======

--- a/tcserver-spring-boot-sample-actuator/README.md
+++ b/tcserver-spring-boot-sample-actuator/README.md
@@ -726,8 +726,8 @@ Example JSON Data:
 Documentation References
 ==========
 
-* Spring Boot - [http://docs.spring.io/spring-boot/docs/1.2.2.RELEASE/reference/htmlsingle/]()
-* tc Server -  [http://tcserver.docs.pivotal.io/index.html]()
+* Spring Boot - [https://docs.spring.io/spring-boot/docs/1.2.2.RELEASE/reference/htmlsingle/]()
+* tc Server -  [https://tcserver.docs.pivotal.io/index.html]()
 
 License
 =======

--- a/tcserver-spring-boot-sample-obfuscated-ssl/README.md
+++ b/tcserver-spring-boot-sample-obfuscated-ssl/README.md
@@ -29,7 +29,7 @@ server.ssl.key-password = password
 
 Note that server.ssl.key-store-password has been encoded using tc Server's property obfuscation feature.
 
-More information about this feature may be found at [http://docs-tcserver-staging.cfapps.io/docs-tcserver/topics/manual.html#obfusc](http://docs-tcserver-staging.cfapps.io/docs-tcserver/topics/manual.html#obfusc)
+More information about this feature may be found at [https://docs-tcserver-staging.cfapps.io/docs-tcserver/topics/manual.html#obfusc](https://docs-tcserver-staging.cfapps.io/docs-tcserver/topics/manual.html#obfusc)
 
 
 License

--- a/tcserver-spring-boot-sample/README.md
+++ b/tcserver-spring-boot-sample/README.md
@@ -34,12 +34,12 @@ Notable pom.xml changes
                 <repository>
                         <id>tcserver-spring-boot-release</id>
                         <name>Pivotal tc Server Spring Boot Starter Release</name>
-                        <url>http://commercial-repo.pivotal.io/data3/tcserver-release-repo/</url>
+                        <url>https://commercial-repo.pivotal.io/data3/tcserver-release-repo/</url>
                 </repository>
                 <repository>
                         <id>tcserver-release-repo</id>
                         <name>Pivotal tc Server Release Repo (3.1.3+)</name>
-                        <url>http://commercial-repo.pivotal.io/data3/tcserver-release-repo/tcserver</url>
+                        <url>https://commercial-repo.pivotal.io/data3/tcserver-release-repo/tcserver</url>
                 </repository>
         </repositories>
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://commercial-repo.pivotal.io/data3/tcserver-release-repo/ (302) with 1 occurrences migrated to:  
  https://commercial-repo.pivotal.io/data3/tcserver-release-repo/ ([https](https://commercial-repo.pivotal.io/data3/tcserver-release-repo/) result 401).
* [ ] http://commercial-repo.pivotal.io/data3/tcserver-release-repo/tcserver (302) with 1 occurrences migrated to:  
  https://commercial-repo.pivotal.io/data3/tcserver-release-repo/tcserver ([https](https://commercial-repo.pivotal.io/data3/tcserver-release-repo/tcserver) result 401).
* [ ] http://docs-tcserver-staging.cfapps.io/docs-tcserver/topics/manual.html (404) with 2 occurrences migrated to:  
  https://docs-tcserver-staging.cfapps.io/docs-tcserver/topics/manual.html ([https](https://docs-tcserver-staging.cfapps.io/docs-tcserver/topics/manual.html) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://docs.spring.io/spring-boot/docs/1.2.2.RELEASE/reference/htmlsingle/ with 3 occurrences migrated to:  
  https://docs.spring.io/spring-boot/docs/1.2.2.RELEASE/reference/htmlsingle/ ([https](https://docs.spring.io/spring-boot/docs/1.2.2.RELEASE/reference/htmlsingle/) result 200).
* [ ] http://projects.spring.io/spring-boot/ with 1 occurrences migrated to:  
  https://projects.spring.io/spring-boot/ ([https](https://projects.spring.io/spring-boot/) result 200).
* [ ] http://tcserver.docs.pivotal.io/index.html with 3 occurrences migrated to:  
  https://tcserver.docs.pivotal.io/index.html ([https](https://tcserver.docs.pivotal.io/index.html) result 301).
* [ ] http://commercial-repo.pivotal.io/ with 1 occurrences migrated to:  
  https://commercial-repo.pivotal.io/ ([https](https://commercial-repo.pivotal.io/) result 302).

# Ignored
These URLs were intentionally ignored.

* http://java.sun.com/jsp/jstl/core with 1 occurrences
* http://localhost with 5 occurrences
* http://localhost:8080/tcserver/ with 2 occurrences
* http://www.springframework.org/tags with 1 occurrences